### PR TITLE
Added a manipulator for prais Radiotext message

### DIFF
--- a/prais.h
+++ b/prais.h
@@ -71,6 +71,10 @@ struct prais_message {
 
 #define PRAIS_MT_MAX_LEN	40
 
+/* Prais RT related */
+#define PRAIS_RT_SPACE_LENGTH 8
+
+
 /* A data frame for Prais Coder mod. 735 */
 struct prais_data_frame {
 	uint8_t no_reply;		/* Set the no reply flag */


### PR DESCRIPTION
@ prais.c
1) Added a manipulator for prais RT messages
2) Added a check to handle empty messages and unimplemented "append" feature

@ prais.h
1) Added a definition (used by the manipulator) about the space length. It is 8 at least for the 735 model ;)
